### PR TITLE
Support Swift 2.0

### DIFF
--- a/EitherSwift.xcodeproj/project.pbxproj
+++ b/EitherSwift.xcodeproj/project.pbxproj
@@ -176,6 +176,8 @@
 		4D4DB77A1A9CE97A0078DECE /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftMigration = 0700;
+				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 0610;
 				ORGANIZATIONNAME = to4iki;
 				TargetAttributes = {

--- a/EitherSwift/Either.swift
+++ b/EitherSwift/Either.swift
@@ -22,12 +22,12 @@ public enum Either<A, B>: EitherType {
     This form is preferred to `Either.Left(Box(value))`
     because it does not require dealing with `Box()`
     
-    :param: value result value
+    - parameter value: result value
     
-    :returns: Left
+    - returns: Left
     */
     public static func left(value: A) -> Either<A, B> {
-        return .Left(Box(value))
+        return Left(Box(value))
     }
     
     /**
@@ -35,12 +35,12 @@ public enum Either<A, B>: EitherType {
     This form is preferred to `Either.Right(Box(value))`
     because it does not require dealing with `Box()`
     
-    :param: value result value
+    - parameter value: result value
     
-    :returns: Right
+    - returns: Right
     */
     public static func right(value: B) -> Either<A, B> {
-        return .Right(Box(value))
+        return Right(Box(value))
     }
     
     /// Projects this `Either` as a `Left`.
@@ -76,10 +76,10 @@ public enum Either<A, B>: EitherType {
     /**
     Applies `fa` if this is a `Left` or `fb` if this is a `Right`.
     
-    :param: fa the function to apply if this is a `Left`
-    :param: fb the function to apply if this is a `Right`
+    - parameter fa: the function to apply if this is a `Left`
+    - parameter fb: the function to apply if this is a `Right`
     
-    :returns: the results of applying the function
+    - returns: the results of applying the function
     */
     public func fold<X>(fa: A -> X, _ fb: B -> X) -> X {
         switch self {
@@ -94,7 +94,7 @@ public enum Either<A, B>: EitherType {
     Flip the left/right values in this disjunction.
     Alias for `~`
     
-    :returns: the results of swap
+    - returns: the results of swap
     */
     public func swap() -> Either<B, A> {
         switch self {
@@ -110,9 +110,9 @@ public enum Either<A, B>: EitherType {
     like null Coalescing Operator.
     Alias for `??`
     
-    :param: or the rawValue function to bind across `Left`.
+    - parameter or: the rawValue function to bind across `Left`.
     
-    :returns: Right Value
+    - returns: Right Value
     */
     public func getOrElse(or: () -> B) -> B {
         return right.getOrElse(or)
@@ -123,9 +123,9 @@ public enum Either<A, B>: EitherType {
     like null Coalescing Operator.
     Alias for `|||`
     
-    :param: or the rawValue function to bind across `Left`.
+    - parameter or: the rawValue function to bind across `Left`.
     
-    :returns: Either<A, B>
+    - returns: Either<A, B>
     */
     public func orElse(or: () -> B) -> Either<A, B> {
         return fold({ _ in Either.right(or()) }, { _ in self })
@@ -136,9 +136,9 @@ public enum Either<A, B>: EitherType {
     like null Coalescing Operator.
     Alias for `|||`
     
-    :param: or the either function to bind across `Left`.
+    - parameter or: the either function to bind across `Left`.
     
-    :returns: Either<A, B>
+    - returns: Either<A, B>
     */
     public func orElse(or: () -> Either<A, B>) -> Either<A, B> {
         return fold({ _ in or() }, { _ in self })
@@ -147,9 +147,9 @@ public enum Either<A, B>: EitherType {
     /**
     Maps `Right` values with `f`, and re-wraps `Left` values.
     
-    :param: f the function to bind across `Right`.
+    - parameter f: the function to bind across `Right`.
     
-    :returns: Either<A, X>
+    - returns: Either<A, X>
     */
     public func map<X>(f: B -> X) -> Either<A, X> {
         return right.map(f)
@@ -159,9 +159,9 @@ public enum Either<A, B>: EitherType {
     Returns the result of applying `f` to `Right` values, or re-wrapping `Left` values.
     Alias for `>>-`
     
-    :param: f the function to bind across `Right`.
+    - parameter f: the function to bind across `Right`.
     
-    :returns: Either<A, X>
+    - returns: Either<A, X>
     */
     public func flatMap<X>(f: B -> Either<A, X>) -> Either<A, X> {
         return right.flatMap(f)
@@ -171,11 +171,11 @@ public enum Either<A, B>: EitherType {
     If the condition is satisfied, return the given `B` in `Right`,
     otherwise, return the given `A` in `Left`.
     
-    :param: test  predicate
-    :param: right the either function to bind across `Right`.
-    :param: left  the either function to bind across `Left`.
+    - parameter test:  predicate
+    - parameter right: the either function to bind across `Right`.
+    - parameter left:  the either function to bind across `Left`.
     
-    :returns: Either<A, B>
+    - returns: Either<A, B>
     */
     public static func cond<A, B>(test: Bool, right: () -> B, left: () -> A) -> Either<A, B> {
         return test ? Either<A, B>.right(right()): Either<A, B>.left(left())
@@ -185,7 +185,7 @@ public enum Either<A, B>: EitherType {
 /**
 *  Printable
 */
-extension Either: Printable {
+extension Either: CustomStringConvertible {
     public var description: String {
         switch self {
         case .Left(let l):
@@ -200,10 +200,10 @@ extension Either: Printable {
 Equatable
 Equality for Either is defined by the equality of the contained types
 
-:param: lhs Left hand side
-:param: rhs right hand side
+- parameter lhs: Left hand side
+- parameter rhs: right hand side
 
-:returns: equal
+- returns: equal
 */
 public func == <A, B where A: Equatable, B: Equatable>(lhs: Either<A, B>, rhs: Either<A, B>) -> Bool {
     switch (lhs, rhs) {
@@ -220,10 +220,10 @@ public func == <A, B where A: Equatable, B: Equatable>(lhs: Either<A, B>, rhs: E
 Equatable
 Inequality for Either is defined by the inequality of the contained types
 
-:param: lhs Left hand side
-:param: rhs right hand side
+- parameter lhs: Left hand side
+- parameter rhs: right hand side
 
-:returns: inequal
+- returns: inequal
 */
 public func != <A, B where A: Equatable, B: Equatable>(lhs: Either<A, B>, rhs: Either<A, B>) -> Bool {
     return !(rhs == lhs)
@@ -232,9 +232,9 @@ public func != <A, B where A: Equatable, B: Equatable>(lhs: Either<A, B>, rhs: E
 /**
 Flip the left/right values in this disjunction. Alias for `swap`
 
-:param: either Either<A, B>
+- parameter either: Either<A, B>
 
-:returns: the results of swap
+- returns: the results of swap
 */
 public prefix func ~ <A, B>(eithr: Either<A, B>) -> Either<B, A> {
     return eithr.swap()
@@ -243,10 +243,10 @@ public prefix func ~ <A, B>(eithr: Either<A, B>) -> Either<B, A> {
 /**
 Return the right value of this disjunction or the given default if left. Alias for `getOrElse`
 
-:param: eithr Either<A, B>
-:param: or    the rawValue function to bind across `Left`.
+- parameter eithr: Either<A, B>
+- parameter or:    the rawValue function to bind across `Left`.
 
-:returns: Right Value
+- returns: Right Value
 */
 public func ?? <A, B>(eithr: Either<A, B>, or:  B) -> B {
     return eithr.getOrElse { or }
@@ -255,10 +255,10 @@ public func ?? <A, B>(eithr: Either<A, B>, or:  B) -> B {
 /**
 Return this if it is a right, otherwise, return the given value. Alias for `orElse`
 
-:param: eithr Either<A, B>
-:param: or    the rawValue function to bind across `Left`.
+- parameter eithr: Either<A, B>
+- parameter or:    the rawValue function to bind across `Left`.
 
-:returns: Either<A, B>
+- returns: Either<A, B>
 */
 public func ||| <A, B>(eithr: Either<A, B>, or:  B) -> Either<A, B> {
     return eithr.orElse { or }
@@ -267,10 +267,10 @@ public func ||| <A, B>(eithr: Either<A, B>, or:  B) -> Either<A, B> {
 /**
 Return this if it is a right, otherwise, return the given value. Alias for `orElse`
 
-:param: eithr Either<A, B>
-:param: or    the either function to bind across `Left`.
+- parameter eithr: Either<A, B>
+- parameter or:    the either function to bind across `Left`.
 
-:returns: Either<A, B>
+- returns: Either<A, B>
 */
 public func ||| <A, B>(eithr: Either<A, B>, or: Either<A, B>) -> Either<A, B> {
     return eithr.orElse { or }
@@ -279,10 +279,10 @@ public func ||| <A, B>(eithr: Either<A, B>, or: Either<A, B>) -> Either<A, B> {
 /**
 Returns the result of applying `f` to `Right` values, or re-wrapping `Left` values. Alias for `flatMap`
 
-:param: either Either<A, B>
-:param: f      the function to bind across `Right`.
+- parameter either: Either<A, B>
+- parameter f:      the function to bind across `Right`.
 
-:returns: Either<A, X>
+- returns: Either<A, X>
 */
 public func >>- <A, B, X>(either: Either<A, B>, f: B -> Either<A, X>) -> Either<A, X> {
     return either.flatMap(f)

--- a/EitherSwift/EitherType.swift
+++ b/EitherSwift/EitherType.swift
@@ -10,15 +10,15 @@
 *  A type representing an alternative of one of two types.
 */
 public protocol EitherType {
-    typealias Left
-    typealias Right
+    typealias LeftValue
+    typealias RightValue
     
     /// Constructs a `Left` instance.
-    static func left(value: Left) -> Self
+    static func left(value: LeftValue) -> Self
     
     /// Constructs a `Right` instance.
-    static func right(value: Right) -> Self
+    static func right(value: RightValue) -> Self
     
     /// Returns the result of applying `f` to `Left` values, or `g` to `Right` values.
-    func fold<Result>(fa: Left -> Result, _ fb: Right -> Result) -> Result
+    func fold<Result>(fa: LeftValue -> Result, _ fb: RightValue -> Result) -> Result
 }

--- a/EitherSwift/Projection.swift
+++ b/EitherSwift/Projection.swift
@@ -36,7 +36,7 @@ public struct LeftProjection<A, B> {
     /**
     Executes the given side-effecting function if this is a `Left`.
     
-    :param: f The side-effecting function to execute.
+    - parameter f: The side-effecting function to execute.
     */
     public func foreach<U>(f: A -> U) {
         switch e {
@@ -73,7 +73,7 @@ public struct LeftProjection<A, B> {
     /**
     Binds the given function across `Left`.
     
-    :param: f the function to bind across `Left`.
+    - parameter f: the function to bind across `Left`.
     */
     public func flatMap<X>(f: A -> Either<X, B>) -> Either<X, B> {
         return e.fold({ f($0) }, { Either.right($0) })
@@ -126,7 +126,7 @@ public struct RightProjection<A, B> {
     /**
     Executes the given side-effecting function if this is a `Right`.
     
-    :param: f the side-effecting function to execute.
+    - parameter f: the side-effecting function to execute.
     */
     public func foreach<U>(f: B -> U) {
         switch e {
@@ -163,7 +163,7 @@ public struct RightProjection<A, B> {
     /**
     Binds the given function across `Right`.
     
-    :param: f the function to bind across `Right`.
+    - parameter f: the function to bind across `Right`.
     */
     public func flatMap<X>(f: B -> Either<A, X>) -> Either<A, X> {
         return e.fold({ Either.left($0) }, { f($0) })

--- a/EitherSwiftTests/EitherSwiftTests.swift
+++ b/EitherSwiftTests/EitherSwiftTests.swift
@@ -15,7 +15,7 @@ struct Error {
 }
 
 struct Helper {
-    static func try(success: Bool, _ message: String) -> Either<Error, String> {
+    static func `try`(success: Bool, _ message: String) -> Either<Error, String> {
         return success ? Either.right(message) : Either.left(Error(message))
     }
 }
@@ -49,10 +49,10 @@ class EitherSwiftTests: XCTestCase {
     }
     
     func testFold() {
-        let e1 = Helper.try(false, "error").fold({ "left \($0.reason)" }, { "right \($0)" })
+        let e1 = Helper.`try`(false, "error").fold({ "left \($0.reason)" }, { "right \($0)" })
         XCTAssertEqual(e1, "left error")
         
-        let e2 = Helper.try(true, "success").fold({ "left \($0.reason)" }, { "right \($0)" })
+        let e2 = Helper.`try`(true, "success").fold({ "left \($0.reason)" }, { "right \($0)" })
         XCTAssertEqual(e2, "right success")
     }
     
@@ -75,24 +75,24 @@ class EitherSwiftTests: XCTestCase {
     }
     
     func testMap() {
-        let e1 = Helper.try(false, "f").map { (s: String) -> String in "\(s) value" }
+        let e1 = Helper.`try`(false, "f").map { (s: String) -> String in "\(s) value" }
         XCTAssertEqual(e1.left.get.reason, "f")
         XCTAssert(e1.right.toOption() == nil)
         
-        let e2 = Helper.try(true, "s").map { (s: String) -> String in "\(s) value" }
+        let e2 = Helper.`try`(true, "s").map { (s: String) -> String in "\(s) value" }
         XCTAssert(e2.left.toOption() == nil)
         XCTAssertEqual(e2.right.get, "s value")
     }
     
     func testFlatMap() {
-        let e1 = Helper.try(false, "f").flatMap { (s: String) -> Either<Error, String> in
+        let e1 = Helper.`try`(false, "f").flatMap { (s: String) -> Either<Error, String> in
             return Either.right("\(s) value")
         }
 
         XCTAssertEqual(e1.left.get.reason, "f")
         XCTAssert(e1.right.toOption() == nil)
         
-        let e2 = Helper.try(true, "s").flatMap { (s: String) -> Either<Error, String> in
+        let e2 = Helper.`try`(true, "s").flatMap { (s: String) -> Either<Error, String> in
             return Either.right("\(s) value")
         }
         XCTAssert(e2.left.toOption() == nil)
@@ -100,40 +100,40 @@ class EitherSwiftTests: XCTestCase {
     }
     
     func testflatMapOperator() {
-        let e1 = (Helper.try(false, "f") >>- Either.right).fold({ _ in "ff"}, { _ in "s"})
+        let e1 = (Helper.`try`(false, "f") >>- Either.right).fold({ _ in "ff"}, { _ in "s"})
         XCTAssertEqual(e1, "ff")
         
-        let e2 = (Helper.try(true, "s") >>- Either.right).fold({ _ in "f"}, { _ in "ss"})
+        let e2 = (Helper.`try`(true, "s") >>- Either.right).fold({ _ in "f"}, { _ in "ss"})
         XCTAssertEqual(e2, "ss")
     }
     
     func testGetOrElse() {
-        let e1 = Helper.try(false, "f").getOrElse { "s" }
+        let e1 = Helper.`try`(false, "f").getOrElse { "s" }
         XCTAssertEqual(e1, "s")
         
-        let e2 = Helper.try(true, "s").getOrElse { "s2" }
+        let e2 = Helper.`try`(true, "s").getOrElse { "s2" }
         XCTAssertEqual(e2, "s")
     }
     
     func testGetOrElseOperator() {
-        let e1 = Helper.try(false, "f") ?? "s"
+        let e1 = Helper.`try`(false, "f") ?? "s"
         XCTAssertEqual(e1, "s")
         
-        let e2 = Helper.try(true, "s") ?? "s2"
+        let e2 = Helper.`try`(true, "s") ?? "s2"
         XCTAssertEqual(e2, "s")
     }
     
     func testOrElseRawValue() {
-        let e1 = Helper.try(false, "f").orElse { "s" }
+        let e1 = Helper.`try`(false, "f").orElse { "s" }
         XCTAssert(e1.left.toOption() == nil)
         XCTAssertEqual(e1.right.get, "s")
         
-        let e2 = Helper.try(true, "s").orElse { "s2" }
+        let e2 = Helper.`try`(true, "s").orElse { "s2" }
         XCTAssert(e2.left.toOption() == nil)
         XCTAssertEqual(e2.right.get, "s")
         
-        let e3 = Helper.try(false, "f1").orElse({
-            Helper.try(false, "f2")
+        let e3 = Helper.`try`(false, "f1").orElse({
+            Helper.`try`(false, "f2")
         }).orElse({
             "s"
         })
@@ -142,29 +142,29 @@ class EitherSwiftTests: XCTestCase {
     }
     
     func testOrElse() {
-        let e1 = Helper.try(false, "f").orElse { Helper.try(true, "s") }
+        let e1 = Helper.`try`(false, "f").orElse { Helper.`try`(true, "s") }
         XCTAssert(e1.left.toOption() == nil)
         XCTAssertEqual(e1.right.get, "s")
         
-        let e2 = Helper.try(true, "s").orElse { Helper.try(true, "s2") }
+        let e2 = Helper.`try`(true, "s").orElse { Helper.`try`(true, "s2") }
         XCTAssert(e2.left.toOption() == nil)
         XCTAssertEqual(e2.right.get, "s")
         
-        let e3 = Helper.try(false, "f1").orElse({
-            Helper.try(false, "f2")
+        let e3 = Helper.`try`(false, "f1").orElse({
+            Helper.`try`(false, "f2")
         }).orElse({
-            Helper.try(true, "s")
+            Helper.`try`(true, "s")
         })
         XCTAssert(e3.left.toOption() == nil)
         XCTAssertEqual(e3.right.get, "s")
     }
     
     func testOrElseOperator() {
-        let e1 = Helper.try(false, "f") ||| "s"
+        let e1 = Helper.`try`(false, "f") ||| "s"
         XCTAssert(e1.left.toOption() == nil)
         XCTAssertEqual(e1.right.get, "s")
         
-        let e2 = Helper.try(false, "f1") ||| Helper.try(false, "f2") ||| Helper.try(true, "s")
+        let e2 = Helper.`try`(false, "f1") ||| Helper.`try`(false, "f2") ||| Helper.`try`(true, "s")
         XCTAssert(e2.left.toOption() == nil)
         XCTAssertEqual(e2.right.get, "s")
     }
@@ -207,13 +207,13 @@ class EitherSwiftTests: XCTestCase {
     }
     
     func testIsLeft() {
-        let e = Helper.try(false, "left")
+        let e = Helper.`try`(false, "left")
         XCTAssert(e.isLeft == true)
         XCTAssert(e.isRight == false)
     }
     
     func testIsRight() {
-        let e = Helper.try(true, "right")
+        let e = Helper.`try`(true, "right")
         XCTAssert(e.isLeft == false)
         XCTAssert(e.isRight == true)
     }

--- a/EitherSwiftTests/ProjectionTests.swift
+++ b/EitherSwiftTests/ProjectionTests.swift
@@ -20,43 +20,43 @@ class ProjectionTests: XCTestCase {
     }
     
     func testLeftGet() {
-        let e = Helper.try(false, "left")
+        let e = Helper.`try`(false, "left")
         XCTAssertEqual(e.left.get.reason, "left")
         // XCTAssertEqual(e.right.get, "left") Runtime Error
     }
     
     func testRightGet() {
-        let e = Helper.try(true, "right")
+        let e = Helper.`try`(true, "right")
         XCTAssertEqual(e.right.get, "right")
         // XCTAssertEqual(e.left.get.reason, "right") Runtime Error
     }
     
     func testLeftToOption() {
-        let e = Helper.try(false, "left")
+        let e = Helper.`try`(false, "left")
         XCTAssert(e.left.toOption()?.reason != nil)
         XCTAssert(e.right.toOption() == nil)
     }
     
     func testRightToOption() {
-        let e = Helper.try(true, "right")
+        let e = Helper.`try`(true, "right")
         XCTAssert(e.left.toOption() == nil)
         XCTAssert(e.right.toOption() != nil)
     }
     
     func testLeftGetOrElse() {
-        let e = Helper.try(false, "left")
+        let e = Helper.`try`(false, "left")
         XCTAssertEqual(e.left.getOrElse { Error("or") }.reason, "left")
         XCTAssertEqual(e.right.getOrElse { "or" }, "or")
     }
     
     func testRightGetOrElse() {
-        let e = Helper.try(true, "right")
+        let e = Helper.`try`(true, "right")
         XCTAssertEqual(e.left.getOrElse { Error("or") }.reason, "or")
         XCTAssertEqual(e.right.getOrElse { "or" }, "right")
     }
     
     func testLeftForeach() {
-        let e = Helper.try(false, "left")
+        let e = Helper.`try`(false, "left")
         
         var (leftWasCall, rightWasCall) = (false, false)
         e.left.foreach { _ in leftWasCall = true }
@@ -67,7 +67,7 @@ class ProjectionTests: XCTestCase {
     }
     
     func testRightForeach() {
-        let e = Helper.try(true, "right")
+        let e = Helper.`try`(true, "right")
         
         var (leftWasCall, rightWasCall) = (false, false)
         e.left.foreach { _ in leftWasCall = true }
@@ -78,31 +78,31 @@ class ProjectionTests: XCTestCase {
     }
     
     func testLeftForall() {
-        let e = Helper.try(false, "left")
-        XCTAssert(e.left.forall { count($0.reason) > 3 } == true)
-        XCTAssert(e.left.forall { count($0.reason) > 4 } == false)
-        XCTAssert(e.right.forall { count($0) > 100 } == true)
+        let e = Helper.`try`(false, "left")
+        XCTAssert(e.left.forall { $0.reason.characters.count > 3 } == true)
+        XCTAssert(e.left.forall { $0.reason.characters.count > 4 } == false)
+        XCTAssert(e.right.forall { $0.characters.count > 100 } == true)
     }
     
     func testRightForall() {
-        let e = Helper.try(true, "right")
-        XCTAssert(e.left.forall { count($0.reason) > 100 } == true)
-        XCTAssert(e.right.forall { count($0) > 4 } == true)
-        XCTAssert(e.right.forall { count($0) > 5 } == false)
+        let e = Helper.`try`(true, "right")
+        XCTAssert(e.left.forall { $0.reason.characters.count > 100 } == true)
+        XCTAssert(e.right.forall { $0.characters.count > 4 } == true)
+        XCTAssert(e.right.forall { $0.characters.count > 5 } == false)
     }
     
     func testLeftExists() {
-        let e = Helper.try(false, "left")
-        XCTAssert(e.left.exists { count($0.reason) > 3 } == true)
-        XCTAssert(e.left.exists { count($0.reason) > 4 } == false)
-        XCTAssert(e.right.exists { count($0) > 100 } == false)
+        let e = Helper.`try`(false, "left")
+        XCTAssert(e.left.exists { $0.reason.characters.count > 3 } == true)
+        XCTAssert(e.left.exists { $0.reason.characters.count > 4 } == false)
+        XCTAssert(e.right.exists { $0.characters.count > 100 } == false)
     }
     
     func testRightExists() {
-        let e = Helper.try(true, "right")
-        XCTAssert(e.left.exists { count($0.reason) > 100 } == false)
-        XCTAssert(e.right.exists { count($0) > 4 } == true)
-        XCTAssert(e.right.exists { count($0) > 5 } == false)
+        let e = Helper.`try`(true, "right")
+        XCTAssert(e.left.exists { $0.reason.characters.count > 100 } == false)
+        XCTAssert(e.right.exists { $0.characters.count > 4 } == true)
+        XCTAssert(e.right.exists { $0.characters.count > 5 } == false)
     }
     
     func testLeftMap() {
@@ -142,16 +142,16 @@ class ProjectionTests: XCTestCase {
     }
     
     func testLeftFilter() {
-        let e = Helper.try(false, "left")
-        XCTAssert(e.left.filter { count($0.reason) > 3 } != nil)
-        XCTAssert(e.left.filter { count($0.reason) > 4 } == nil)
-        XCTAssert(e.right.filter { count($0) > 100 } == nil)
+        let e = Helper.`try`(false, "left")
+        XCTAssert(e.left.filter { $0.reason.characters.count > 3 } != nil)
+        XCTAssert(e.left.filter { $0.reason.characters.count > 4 } == nil)
+        XCTAssert(e.right.filter { $0.characters.count > 100 } == nil)
     }
     
     func testRightFilter() {
-        let e = Helper.try(true, "right")
-        XCTAssert(e.left.filter { count($0.reason) > 100 } == nil)
-        XCTAssert(e.right.filter { count($0) > 4 } != nil)
-        XCTAssert(e.right.filter { count($0) > 5 } == nil)
+        let e = Helper.`try`(true, "right")
+        XCTAssert(e.left.filter { $0.reason.characters.count > 100 } == nil)
+        XCTAssert(e.right.filter { $0.characters.count > 4 } != nil)
+        XCTAssert(e.right.filter { $0.characters.count > 5 } == nil)
     }
 }


### PR DESCRIPTION
- typealias is renamed because typealias Left, Right confilcts.
- comment format changed to adapt Swift 2.0.
